### PR TITLE
Release 0.0.4

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.3
+current_version = 0.0.4
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = 
 	{major}.{minor}.{patch}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.0.4] - 2022-09-09
+### Fixed
+- Fix python 3.8 compatibility for `removeprefix`
+
 ## [0.0.3] - 2022-09-09
 ### Added
 - Support for dagstermill

--- a/papermill_origami/_version.py
+++ b/papermill_origami/_version.py
@@ -1,1 +1,1 @@
-version = "0.0.3"
+version = "0.0.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 
 [tool.poetry]
 name = "papermill-origami"
-version = "0.0.3"
+version = "0.0.4"
 description = "The noteable API interface"
 authors = ["Matt Seal <matt@noteable.io>"]
 maintainers = ["Matt Seal <matt@noteable.io>"]


### PR DESCRIPTION
### Fixed
- Fix python 3.8 compatibility for `removeprefix`