### PR TITLE
Bump noteable-origami to 0.0.6

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.6
+current_version = 0.0.7
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = 
 	{major}.{minor}.{patch}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.0.7] - 2022-10-05
+### Changed
+- Bump `noteable-origami` dependency to 0.0.6
+
 ## [0.0.6] - 2022-10-05
 ### Changed
 - `execute_notebook` need not be passed in a `logger` instance explicitly, it will use the module-level logger if one is not provided.

--- a/papermill_origami/_version.py
+++ b/papermill_origami/_version.py
@@ -1,1 +1,1 @@
-version = "0.0.6"
+version = "0.0.7"

--- a/poetry.lock
+++ b/poetry.lock
@@ -987,7 +987,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "noteable-origami"
-version = "0.0.5"
+version = "0.0.6"
 description = "The Noteable API interface"
 category = "main"
 optional = false
@@ -1953,7 +1953,7 @@ dagster = ["dagstermill"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "e63c49a41f063fd3539cb955c0dcfdc163157e48381a57be7425a2740305f9b1"
+content-hash = "032267e9597ee88a6e30f4717731477528870d14335c999b05faad62fe9e243e"
 
 [metadata.files]
 alembic = [
@@ -2642,8 +2642,8 @@ nest-asyncio = [
     {file = "nest_asyncio-1.5.5.tar.gz", hash = "sha256:e442291cd942698be619823a17a86a5759eabe1f8613084790de189fe9e16d65"},
 ]
 noteable-origami = [
-    {file = "noteable-origami-0.0.5.tar.gz", hash = "sha256:c9307344ff3986e249b0e2a53090f50e62bab81c5c741860a5397a5783864cca"},
-    {file = "noteable_origami-0.0.5-py3-none-any.whl", hash = "sha256:865bc45db114f22cb949a3a88fc3cbac4133ae8606a35fd04faa7e6c49cc988a"},
+    {file = "noteable-origami-0.0.6.tar.gz", hash = "sha256:95a80e4a2b1a812b206dfbfd32381e4c4988ac9a1ff7d51c3f98b3fa8401e16c"},
+    {file = "noteable_origami-0.0.6-py3-none-any.whl", hash = "sha256:91fb38ce8bbf333a0ab38ec408504e5c2a47e9255eb2769cbe58e3e32d730c80"},
 ]
 notebook = [
     {file = "notebook-6.4.12-py3-none-any.whl", hash = "sha256:8c07a3bb7640e371f8a609bdbb2366a1976c6a2589da8ef917f761a61e3ad8b1"},
@@ -3046,7 +3046,9 @@ python-dateutil = [
 python-editor = [
     {file = "python-editor-1.0.4.tar.gz", hash = "sha256:51fda6bcc5ddbbb7063b2af7509e43bd84bfc32a4ff71349ec7847713882327b"},
     {file = "python_editor-1.0.4-py2-none-any.whl", hash = "sha256:5f98b069316ea1c2ed3f67e7f5df6c0d8f10b689964a4a811ff64f0106819ec8"},
+    {file = "python_editor-1.0.4-py2.7.egg", hash = "sha256:ea87e17f6ec459e780e4221f295411462e0d0810858e055fc514684350a2f522"},
     {file = "python_editor-1.0.4-py3-none-any.whl", hash = "sha256:1bf6e860a8ad52a14c3ee1252d5dc25b2030618ed80c022598f00176adc8367d"},
+    {file = "python_editor-1.0.4-py3.5.egg", hash = "sha256:c3da2053dbab6b29c94e43c486ff67206eafbe7eb52dbec7390b5e2fb05aac77"},
 ]
 pytz = [
     {file = "pytz-2022.2.1-py2.py3-none-any.whl", hash = "sha256:220f481bdafa09c3955dfbdddb7b57780e9a94f5127e35456a48589b9e0c0197"},
@@ -3087,13 +3089,6 @@ PyYAML = [
     {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
     {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
     {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
-    {file = "PyYAML-6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d4b0ba9512519522b118090257be113b9468d804b19d63c71dbcf4a48fa32358"},
-    {file = "PyYAML-6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:81957921f441d50af23654aa6c5e5eaf9b06aba7f0a19c18a538dc7ef291c5a1"},
-    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afa17f5bc4d1b10afd4466fd3a44dc0e245382deca5b3c353d8b757f9e3ecb8d"},
-    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dbad0e9d368bb989f4515da330b88a057617d16b6a8245084f1b05400f24609f"},
-    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:432557aa2c09802be39460360ddffd48156e30721f5e8d917f01d31694216782"},
-    {file = "PyYAML-6.0-cp311-cp311-win32.whl", hash = "sha256:bfaef573a63ba8923503d27530362590ff4f576c626d86a9fed95822a8255fd7"},
-    {file = "PyYAML-6.0-cp311-cp311-win_amd64.whl", hash = "sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf"},
     {file = "PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
     {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
     {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},
@@ -3290,6 +3285,7 @@ structlog = [
 ]
 tabulate = [
     {file = "tabulate-0.8.10-py3-none-any.whl", hash = "sha256:0ba055423dbaa164b9e456abe7920c5e8ed33fcc16f6d1b2f2d152c8e1e8b4fc"},
+    {file = "tabulate-0.8.10-py3.8.egg", hash = "sha256:436f1c768b424654fce8597290d2764def1eea6a77cfa5c33be00b1bc0f4f63d"},
     {file = "tabulate-0.8.10.tar.gz", hash = "sha256:6c57f3f3dd7ac2782770155f3adb2db0b1a269637e42f27599925e64b114f519"},
 ]
 tenacity = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ url = "https://pypi.org"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-noteable-origami = "^0.0.5"
+noteable-origami = "0.0.6"
 papermill = "^2.4.0"
 dagstermill = {version = "^1.0.5", optional = true}
 cloudpickle = "^2.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ url = "https://pypi.org"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-noteable-origami = "0.0.6"
+noteable-origami = "^0.0.6"
 papermill = "^2.4.0"
 dagstermill = {version = "^1.0.5", optional = true}
 cloudpickle = "^2.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 
 [tool.poetry]
 name = "papermill-origami"
-version = "0.0.6"
+version = "0.0.7"
 description = "The noteable API interface"
 authors = ["Matt Seal <matt@noteable.io>"]
 maintainers = ["Matt Seal <matt@noteable.io>"]
@@ -34,7 +34,7 @@ url = "https://pypi.org"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-noteable-origami = "^0.0.6"
+noteable-origami = "^0.0.7"
 papermill = "^2.4.0"
 dagstermill = {version = "^1.0.5", optional = true}
 cloudpickle = "^2.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ url = "https://pypi.org"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-noteable-origami = "^0.0.7"
+noteable-origami = "^0.0.6"
 papermill = "^2.4.0"
 dagstermill = {version = "^1.0.5", optional = true}
 cloudpickle = "^2.2.0"


### PR DESCRIPTION
I should have released 0.0.6 with this upgrade. I'll try to re-release to 0.0.6.