### PR TITLE
Sync all papermill metadata to Noteable

### DIFF
--- a/papermill_origami/engine.py
+++ b/papermill_origami/engine.py
@@ -198,8 +198,8 @@ class NoteableEngine(Engine):
 
             await self.papermill_execute_cells()
 
-            # WARNING: This is a hack to ensure we have the client in session to send nb metadata
-            #          updates over RTU after execution.
+            # This is a hack to ensure we have the client in session to send nb metadata
+            # updates over RTU after execution.
             self.nb_man.notebook_complete()
             await self.sync_noteable_nb_metadata_with_papermill()
 

--- a/papermill_origami/engine.py
+++ b/papermill_origami/engine.py
@@ -99,7 +99,7 @@ class NoteableEngine(Engine):
 
     def catch_cell_metadata_updates(self, func):
         """A decorator for catching cell metadata updates related to papermill
-         and updating the Noteable notebook via RTU"""
+        and updating the Noteable notebook via RTU"""
 
         @functools.wraps(func)
         def wrapper(cell, *args, **kwargs):
@@ -107,7 +107,9 @@ class NoteableEngine(Engine):
             # Update Noteable cell metadata
             if not cell.metadata.get("papermill"):
                 return ret_val
-            for key, value in flatten_dict(cell.metadata.papermill, parent_key_tuple=("papermill",)).items():
+            for key, value in flatten_dict(
+                cell.metadata.papermill, parent_key_tuple=("papermill",)
+            ).items():
                 run_sync(self.km.client.update_cell_metadata)(
                     file=self.file,
                     cell_id=cell.id,
@@ -246,7 +248,9 @@ class NoteableEngine(Engine):
         the Noteable notebook"""
         if not self.nb.metadata.get("papermill"):
             return
-        for key, value in flatten_dict(self.nb.metadata.papermill, parent_key_tuple=("parameters",)).items():
+        for key, value in flatten_dict(
+            self.nb.metadata.papermill, parent_key_tuple=("parameters",)
+        ).items():
             await self.km.client.update_nb_metadata(self.file, {"path": key, "value": value})
 
     @staticmethod

--- a/papermill_origami/engine.py
+++ b/papermill_origami/engine.py
@@ -98,13 +98,14 @@ class NoteableEngine(Engine):
         self.file = None
 
     def catch_cell_metadata_updates(self, func):
-        """A decorator for catching cell metadata updates and updating the Noteable notebook via RTU"""
+        """A decorator for catching cell metadata updates related to papermill
+         and updating the Noteable notebook via RTU"""
 
         @functools.wraps(func)
         def wrapper(cell, *args, **kwargs):
             ret_val = func(cell, *args, **kwargs)
             # Update Noteable cell metadata
-            for key, value in flatten_dict(cell.metadata).items():
+            for key, value in flatten_dict(cell.metadata.papermill, parent_key_tuple=("papermill",)).items():
                 run_sync(self.km.client.update_cell_metadata)(
                     file=self.file,
                     cell_id=cell.id,
@@ -239,9 +240,9 @@ class NoteableEngine(Engine):
         )
 
     async def sync_noteable_nb_metadata_with_papermill(self):
-        """Used to sync the metadata of in-memory notebook representation that papermill manages with
+        """Used to sync the papermill metadata of in-memory notebook representation that papermill manages with
         the Noteable notebook"""
-        for key, value in flatten_dict(self.nb.metadata).items():
+        for key, value in flatten_dict(self.nb.metadata.papermill, parent_key_tuple=("parameters",)).items():
             await self.km.client.update_nb_metadata(self.file, {"path": key, "value": value})
 
     @staticmethod

--- a/papermill_origami/engine.py
+++ b/papermill_origami/engine.py
@@ -105,6 +105,8 @@ class NoteableEngine(Engine):
         def wrapper(cell, *args, **kwargs):
             ret_val = func(cell, *args, **kwargs)
             # Update Noteable cell metadata
+            if not cell.metadata.get("papermill"):
+                return ret_val
             for key, value in flatten_dict(cell.metadata.papermill, parent_key_tuple=("papermill",)).items():
                 run_sync(self.km.client.update_cell_metadata)(
                     file=self.file,
@@ -242,6 +244,8 @@ class NoteableEngine(Engine):
     async def sync_noteable_nb_metadata_with_papermill(self):
         """Used to sync the papermill metadata of in-memory notebook representation that papermill manages with
         the Noteable notebook"""
+        if not self.nb.metadata.get("papermill"):
+            return
         for key, value in flatten_dict(self.nb.metadata.papermill, parent_key_tuple=("parameters",)).items():
             await self.km.client.update_nb_metadata(self.file, {"path": key, "value": value})
 

--- a/papermill_origami/engine.py
+++ b/papermill_origami/engine.py
@@ -208,7 +208,7 @@ class NoteableEngine(Engine):
             self.nb_man.notebook_complete()
             await self.sync_noteable_nb_metadata_with_papermill()
 
-            # Now override the notebook_complete method and set it to a no-op (since we already called it)
+            # Override the notebook_complete method and set it to a no-op (since we already called it)
             self.nb_man.notebook_complete = lambda: None
 
             # info_msg = self.wait_for_reply(self.kc.kernel_info())
@@ -249,7 +249,7 @@ class NoteableEngine(Engine):
         if not self.nb.metadata.get("papermill"):
             return
         for key, value in flatten_dict(
-            self.nb.metadata.papermill, parent_key_tuple=("parameters",)
+            self.nb.metadata.papermill, parent_key_tuple=("papermill",)
         ).items():
             await self.km.client.update_nb_metadata(self.file, {"path": key, "value": value})
 

--- a/papermill_origami/tests/test_engine.py
+++ b/papermill_origami/tests/test_engine.py
@@ -110,7 +110,7 @@ async def test_propagate_cell_execution_error(mocker, file, file_content, noteab
     )
 
     noteable_engine.nb_man.cell_exception.assert_called_once_with(
-        file_content.cells[-1], cell_index=len(file_content.cells) - 1, exception=ANY
+        file_content.cells[-1], len(file_content.cells) - 1, exception=ANY
     )
 
 

--- a/papermill_origami/tests/test_engine.py
+++ b/papermill_origami/tests/test_engine.py
@@ -123,6 +123,7 @@ async def test_propagate_cell_execution_error(mocker, file, file_content, noteab
             {"tags": ["parameters"], "jupyter": {"source_hidden": True}},
             {("tags",): ["parameters"], ("jupyter", "source_hidden"): True},
         ),
+        ({"default_parameters": {}}, {("default_parameters",): {}}),
         ({}, {}),
     ],
 )

--- a/papermill_origami/tests/test_engine.py
+++ b/papermill_origami/tests/test_engine.py
@@ -131,3 +131,22 @@ def test_flatten_dict(d, expected):
     from papermill_origami.util import flatten_dict
 
     assert flatten_dict(d) == expected
+
+
+@pytest.mark.parametrize(
+    "d, parent_key_tuple, expected",
+    [
+        ({"a": {"b": 1, "c": 2}}, ("parent",), {("parent", "a", "b"): 1, ("parent", "a", "c"): 2}),
+        (
+            {"tags": ["parameters"], "jupyter": {"source_hidden": True}},
+            ("metadata",),
+            {("metadata", "tags",): ["parameters"], ("metadata", "jupyter", "source_hidden"): True},
+        ),
+        ({}, (), {}),
+    ],
+)
+def test_flatten_dict_with_parent_key_tuple(d, parent_key_tuple, expected):
+    # avoid circular import due to papermill engine registration
+    from papermill_origami.util import flatten_dict
+
+    assert flatten_dict(d, parent_key_tuple) == expected

--- a/papermill_origami/tests/test_engine.py
+++ b/papermill_origami/tests/test_engine.py
@@ -112,3 +112,22 @@ async def test_propagate_cell_execution_error(mocker, file, file_content, noteab
     noteable_engine.nb_man.cell_exception.assert_called_once_with(
         file_content.cells[-1], cell_index=len(file_content.cells) - 1, exception=ANY
     )
+
+
+@pytest.mark.parametrize(
+    "d, expected",
+    [
+        ({"a": {"b": 1, "c": 2}}, {("a", "b"): 1, ("a", "c"): 2}),
+        ({"a": {"b": 1, "c": {"d": 4}}}, {("a", "b"): 1, ("a", "c", "d"): 4}),
+        (
+            {"tags": ["parameters"], "jupyter": {"source_hidden": True}},
+            {("tags",): ["parameters"], ("jupyter", "source_hidden"): True},
+        ),
+        ({}, {}),
+    ],
+)
+def test_flatten_dict(d, expected):
+    # avoid circular import due to papermill engine registration
+    from papermill_origami.util import flatten_dict
+
+    assert flatten_dict(d) == expected

--- a/papermill_origami/tests/test_engine.py
+++ b/papermill_origami/tests/test_engine.py
@@ -140,7 +140,13 @@ def test_flatten_dict(d, expected):
         (
             {"tags": ["parameters"], "jupyter": {"source_hidden": True}},
             ("metadata",),
-            {("metadata", "tags",): ["parameters"], ("metadata", "jupyter", "source_hidden"): True},
+            {
+                (
+                    "metadata",
+                    "tags",
+                ): ["parameters"],
+                ("metadata", "jupyter", "source_hidden"): True,
+            },
         ),
         ({}, (), {}),
     ],

--- a/papermill_origami/util.py
+++ b/papermill_origami/util.py
@@ -18,7 +18,7 @@ def flatten_dict(d, parent_key_tuple: tuple = ()):
     items = {}
     for k, v in d.items():
         new_key_tuple = parent_key_tuple + (k,) if parent_key_tuple else (k,)
-        if isinstance(v, dict):
+        if isinstance(v, dict) and v:
             items.update(flatten_dict(v, new_key_tuple))
         else:
             items[new_key_tuple] = v

--- a/papermill_origami/util.py
+++ b/papermill_origami/util.py
@@ -6,8 +6,7 @@ def removeprefix(s, prefix):
 
 
 def flatten_dict(d, parent_key_tuple: tuple = ()):
-    """Flattens a dictionary into a list of tuples with the first element as a list of keys
-    and the second element as the value
+    """Flattens a dictionary into a dict mapped from tuples of keys to values.
 
     Usage:
     >>> flatten_dict({"a": {"b": 1, "c": 2}})

--- a/papermill_origami/util.py
+++ b/papermill_origami/util.py
@@ -3,3 +3,23 @@ def removeprefix(s, prefix):
         return s[len(prefix) :]
     else:
         return s[:]
+
+
+def flatten_dict(d, parent_key_tuple: tuple = ()):
+    """Flattens a dictionary into a list of tuples with the first element as a list of keys
+    and the second element as the value
+
+    Usage:
+    >>> flatten_dict({"a": {"b": 1, "c": 2}})
+    {("a", "b"): 1, ("a", "c"): 2}
+    >>> flatten_dict({"tags": ["parameters"], "jupyter": {"source_hidden": True}})
+    {("tags",): ["parameters"], ("jupyter", "source_hidden"): True}
+    """
+    items = {}
+    for k, v in d.items():
+        new_key_tuple = parent_key_tuple + (k,) if parent_key_tuple else (k,)
+        if isinstance(v, dict):
+            items.update(flatten_dict(v, new_key_tuple))
+        else:
+            items[new_key_tuple] = v
+    return items


### PR DESCRIPTION
This PR ensures that any and all `papermill` metadata updates are synced back into the Noteable notebook.

nbdiff output from a recent run on app.noteable.io - executed notebook from Noteable and output notebook from papermill are diffed.

[diff.html.zip](https://github.com/noteable-io/papermill-origami/files/9822292/diff.html.zip)
