### PR TITLE
Allow specifying job instance attempt kwarg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Add support for flyte
+- Allow specifying `job_instance_attempt` in engine kwargs
 
 ## [0.0.7] - 2022-10-05
 ### Changed

--- a/papermill_origami/engine.py
+++ b/papermill_origami/engine.py
@@ -142,7 +142,7 @@ class NoteableEngine(Engine):
             else:
                 raise ValueError("No file_id or derivable file_id found for noteable scheme")
 
-        job_instance_attempt = None
+        job_instance_attempt = kwargs.get("job_instance_attempt")
         if job_metadata := kwargs.get("job_metadata", {}):
             version = await self.client.get_version_or_none(original_notebook_id)
             if version is not None:


### PR DESCRIPTION
This will be used as a default if `job_metadata` is not supplied.