### PR TITLE
Delete kernel session after successful notebook execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added origami client call to delete the active kernel session after successful notebook execution
+
 ## [0.0.11] - 2022-11-18
 ### Added
 - Added API calls to update job instance attempt status during execution

--- a/papermill_origami/engine.py
+++ b/papermill_origami/engine.py
@@ -411,6 +411,7 @@ class NoteableEngine(Engine):
         for index, cell in enumerate(self.nb.cells):
             try:
                 self._cell_start(cell, index)
+                print(f"Executing cell {index}")
                 await self.async_execute_cell(cell, index)
             except CellExecutionError as ex:
                 # TODO: Make sure we raise these
@@ -432,6 +433,11 @@ class NoteableEngine(Engine):
                 job_instance_attempt_id=self.job_instance_attempt.id,
                 job_instance_attempt_update=JobInstanceAttemptUpdate(status=status),
             )
+
+        if not errored:
+            # Delete the kernel session
+            logger.debug("Deleting kernel session for file id %s", self.file.id)
+            await self.client.delete_kernel_session(self.file)
 
     def _get_timeout(self, cell: Optional[NotebookNode]) -> int:
         """Helper to fetch a timeout as a value or a function to be run against a cell"""


### PR DESCRIPTION
Resolves #75 

## Summary of changes

- Added origami API call to delete kernel session after successful notebook execution
- Added unit tests