### PR TITLE
Mark job attempts as failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Mark job instance attempt failed when any uncaught exception is thrown (including connecting to the kernel)
+
 ## [0.0.11] - 2022-11-18
 ### Added
 - Added API calls to update job instance attempt status during execution


### PR DESCRIPTION
When there's an uncaught error setting up the kernel or something else, the job instance attempt should be marked as failed. Best when viewed with `?w=1`