### PR TITLE
Misc fixes and improvements

### DIFF
--- a/papermill_origami/engine.py
+++ b/papermill_origami/engine.py
@@ -9,6 +9,7 @@ import logging
 from contextlib import asynccontextmanager
 from typing import Generator, Optional
 
+import httpx
 import nbformat
 import orjson
 from jupyter_client.utils import run_sync
@@ -224,9 +225,6 @@ class NoteableEngine(Engine):
             )
         else:
             ext_logger.info(f"Parameterized notebook available at {parameterized_url}")
-        # HACK: We need this delay in order to successfully subscribe to the files channel
-        #       of the newly created parameterized notebook.
-        await asyncio.sleep(1)
 
         try:
             async with self.setup_kernel(file=self.file, client=self.client, **kwargs):
@@ -333,10 +331,6 @@ class NoteableEngine(Engine):
         if self.km is None:
             # Assumes that file and client are being passed in
             self.km = self.create_kernel_manager(**kwargs)
-
-        # Subscribe to the file or we won't see status updates
-        await self.client.subscribe_file(self.km.file, from_version_id=self.file.current_version_id)
-        ext_logger.info("Subscribed to file")
 
         await self.km.async_start_kernel(**kwargs)
         ext_logger.info("Started kernel")
@@ -447,7 +441,13 @@ class NoteableEngine(Engine):
         if not errored:
             # Delete the kernel session
             logger.debug("Deleting kernel session for file id %s", self.file.id)
-            await self.client.delete_kernel_session(self.file)
+            try:
+                await self.client.delete_kernel_session(self.file)
+            except httpx.ReadTimeout as e:
+                logger.warning(
+                    "Timed out while deleting kernel session for file id %s",
+                    self.file.id,
+                )
 
     def _get_timeout(self, cell: Optional[NotebookNode]) -> int:
         """Helper to fetch a timeout as a value or a function to be run against a cell"""


### PR DESCRIPTION
## Summary of changes

- Remove the `asyncio.sleep` right before `setup_kernel`, which was needed since we tried to RTU subscribe to a file as soon as the parameterized notebook was created.
- Remove the redundant `subscribe_file` call -- we already subscribe to the file when trying to launch a new kernel (in `origami.client.NoteableClient.get_or_launch_kernel_session`)
-  Catch `httpx.ReadTimeout` error when trying to delete the kernel session -- if we're trying to delete the kernel session, it means the run has succeeded.